### PR TITLE
Added DSL for pretty brigadier commands

### DIFF
--- a/src/main/kotlin/BrigadierDsl.kt
+++ b/src/main/kotlin/BrigadierDsl.kt
@@ -1,0 +1,114 @@
+import com.mojang.brigadier.arguments.*
+import com.mojang.brigadier.builder.ArgumentBuilder
+import com.mojang.brigadier.builder.LiteralArgumentBuilder
+import com.mojang.brigadier.builder.RequiredArgumentBuilder
+import com.mojang.brigadier.context.CommandContext
+import net.ayataka.kordis.event.events.message.MessageReceiveEvent
+
+@DslMarker
+@Target(AnnotationTarget.TYPE)
+annotation class BrigadierDsl
+
+/**
+ * Appends a new [literal](LiteralArgumentBuilder) to `this` [ArgumentBuilder].
+ *
+ * @param name the name of the literal argument
+ * @param block the receiver function for further construction of the literal argument
+ */
+fun <T> ArgumentBuilder<T, *>.literal(name: String, block: (@BrigadierDsl LiteralArgumentBuilder<T>).() -> Unit) =
+        then(LiteralArgumentBuilder.literal<T>(name).also(block))
+
+/**
+ * Appends a new required argument to `this` [ArgumentBuilder].
+ *
+ * @param name the name of the required argument
+ * @param argument the type of required argument, for example [IntegerArgumentType]
+ * @param block the receiver function for further construction of the required argument
+ */
+fun <S, T : ArgumentBuilder<S, T>, R> ArgumentBuilder<S, T>.argument(
+        name: String,
+        argument: ArgumentType<R>,
+        block: (@BrigadierDsl RequiredArgumentBuilder<S, R>).() -> Unit
+) =
+        then(RequiredArgumentBuilder.argument<S, R>(name, argument).also(block))
+
+/**
+ * A shorthand for appending a boolean required argument to `this` [ArgumentBuilder]
+ *
+ * @see argument
+ */
+fun <S, T : ArgumentBuilder<S, T>> ArgumentBuilder<S, T>.bool(name: String, block: (@BrigadierDsl RequiredArgumentBuilder<S, Boolean>).() -> Unit) =
+        argument(name, BoolArgumentType.bool(), block)
+
+/**
+ * A shorthand for appending a double required argument to `this` [ArgumentBuilder]
+ *
+ * @see argument
+ */
+fun <S, T : ArgumentBuilder<S, T>> ArgumentBuilder<S, T>.double(name: String, block: RequiredArgumentBuilder<S, Double>.() -> Unit) =
+        argument(name, DoubleArgumentType.doubleArg(), block)
+
+/**
+ * A shorthand for appending a float required argument to `this` [ArgumentBuilder]
+ *
+ * @see argument
+ */
+fun <S, T : ArgumentBuilder<S, T>> ArgumentBuilder<S, T>.float(name: String, block: (@BrigadierDsl RequiredArgumentBuilder<S, Float>).() -> Unit) =
+        argument(name, FloatArgumentType.floatArg(), block)
+
+/**
+ * A shorthand for appending a integer required argument to `this` [ArgumentBuilder]
+ *
+ * @see argument
+ */
+fun <S, T : ArgumentBuilder<S, T>> ArgumentBuilder<S, T>.integer(name: String, block: (@BrigadierDsl RequiredArgumentBuilder<S, Int>).() -> Unit) =
+        argument(name, IntegerArgumentType.integer(), block)
+
+/**
+ * A shorthand for appending a `long` required argument to `this` [ArgumentBuilder]
+ *
+ * @see argument
+ */
+fun <S, T : ArgumentBuilder<S, T>> ArgumentBuilder<S, T>.long(name: String, block: (@BrigadierDsl RequiredArgumentBuilder<S, Long>).() -> Unit) =
+        argument(name, LongArgumentType.longArg(), block)
+
+/**
+ * A shorthand for appending a string required argument to `this` [ArgumentBuilder]
+ *
+ * @see argument
+ */
+fun <S, T : ArgumentBuilder<S, T>> ArgumentBuilder<S, T>.string(name: String, block: (@BrigadierDsl RequiredArgumentBuilder<S, String>).() -> Unit) =
+        argument(name, StringArgumentType.string(), block)
+
+/**
+ * A shorthand for appending a greedy string required argument to `this` [ArgumentBuilder]
+ *
+ * @see argument
+ */
+fun <S, T : ArgumentBuilder<S, T>> ArgumentBuilder<S, T>.greedyString(name: String, block: (@BrigadierDsl RequiredArgumentBuilder<S, String>).() -> Unit) =
+        argument(name, StringArgumentType.greedyString(), block)
+
+/**
+ * Sets the executes callback for `this` [ArgumentBuilder]
+ *
+ * @param command the callback
+ */
+infix fun <S> ArgumentBuilder<S, *>.does(command: (@BrigadierDsl CommandContext<S>) -> Int) = executes(command)
+
+/**
+ * Shorthand for [doesLater] with an empty [now] handler that always returns `0`.
+ */
+infix fun ArgumentBuilder<Cmd, *>.doesLater(later: suspend MessageReceiveEvent.(CommandContext<Cmd>) -> Unit) =
+        does { context ->
+            context.source later {
+                later(this, context)
+            }
+            0
+        }
+
+/**
+ * Gets the value of a (required) argument in the command hierarchy
+ *
+ * @see CommandContext.getArgument
+ */
+inline infix fun <reified R, S> CommandContext<S>.arg(name: String) = getArgument(name, R::class.java)

--- a/src/main/kotlin/commands/ArchiveCommand.kt
+++ b/src/main/kotlin/commands/ArchiveCommand.kt
@@ -2,6 +2,7 @@ package commands
 
 import Command
 import commands.ArchiveCommand.executes
+import doesLater
 import net.ayataka.kordis.entity.edit
 import net.ayataka.kordis.entity.server.permission.PermissionSet
 import net.ayataka.kordis.entity.server.permission.overwrite.RolePermissionOverwrite
@@ -10,44 +11,40 @@ import net.ayataka.kordis.entity.server.permission.overwrite.UserPermissionOverw
 // TODO: make utils for permissions because this is all going to become very boilerplate
 object ArchiveCommand : Command("archive") {
     init {
-        executes {
-            it.source later {
-                if (message.author?.id != 563138570953687061) {
+        doesLater { context ->
+            if (message.author?.id != 563138570953687061) {
+                message.channel.send {
+                    embed {
+                        author(name = server?.name)
+                        field("Error", "You don't have permission to use this command!", true)
+                    }
+                }
+            } else {
+                val channel = server?.channels?.find(message.channel.id)
+                val userOverrides: Collection<UserPermissionOverwrite>? = server?.channels?.find(channel!!.id)?.userPermissionOverwrites
+                val roleOverrides: Collection<RolePermissionOverwrite>? = server?.channels?.find(channel!!.id)?.rolePermissionOverwrites
+                val allow = PermissionSet(0)
+                val deny = PermissionSet(3072) // read + send
+                val role = server?.roles?.filter { r -> r.isEveryone }!!
+                val archivedChannelsNum = server?.channels?.filter { c -> c.name.contains(Regex("archived")) }?.size
+                val oldName = channel?.name
+                if (userOverrides == null || roleOverrides == null) {
+                    message.channel.send("No user/role overrides found!")
+                } else {
+                    channel?.edit {
+                        this.name = "archived-$archivedChannelsNum"
+                        this.userPermissionOverwrites.removeAll(userOverrides)
+                        this.rolePermissionOverwrites.removeAll(roleOverrides)
+                        this.rolePermissionOverwrites.add(RolePermissionOverwrite(role[0], allow, deny))
+                    }
                     message.channel.send {
                         embed {
-                            author(name = server?.name)
-                            field("Error", "You don't have permission to use this command!", true)
-                        }
-                    }
-                } else {
-                    val channel = server?.channels?.find(message.channel.id)
-                    val userOverrides: Collection<UserPermissionOverwrite>? = server?.channels?.find(channel!!.id)?.userPermissionOverwrites
-                    val roleOverrides: Collection<RolePermissionOverwrite>? = server?.channels?.find(channel!!.id)?.rolePermissionOverwrites
-                    val allow = PermissionSet(0)
-                    val deny = PermissionSet(3072) // read + send
-                    val role = server?.roles?.filter { r -> r.isEveryone }!!
-                    val archivedChannelsNum = server?.channels?.filter { c -> c.name.contains(Regex("archived")) }?.size
-                    val oldName = channel?.name
-                    if (userOverrides == null || roleOverrides == null) {
-                        message.channel.send("No user/role overrides found!")
-                    } else {
-                        channel?.edit {
-                            this.name = "archived-$archivedChannelsNum"
-                            this.userPermissionOverwrites.removeAll(userOverrides)
-                            this.rolePermissionOverwrites.removeAll(roleOverrides)
-                            this.rolePermissionOverwrites.add(RolePermissionOverwrite(role[0], allow, deny))
-                        }
-                        message.channel.send {
-                            embed {
-                                author(name = message.author?.name)
-                                field("Success", "Changed name from `$oldName` to `archived-$archivedChannelsNum`", true)
-                            }
-
+                            author(name = message.author?.name)
+                            field("Success", "Changed name from `$oldName` to `archived-$archivedChannelsNum`", true)
                         }
                     }
                 }
             }
-            0
         }
     }
 }

--- a/src/main/kotlin/commands/ExampleCommand.kt
+++ b/src/main/kotlin/commands/ExampleCommand.kt
@@ -2,6 +2,15 @@ package commands
 
 import Cmd
 import Command
+import arg
+import argument
+import com.mojang.brigadier.arguments.IntegerArgumentType
+import does
+import doesLater
+import greedyString
+import integer
+import literal
+import string
 
 /**
  * @author dominikaaaa
@@ -9,15 +18,27 @@ import Command
  */
 object ExampleCommand : Command("ec") {
     init {
-        then(literal<Cmd>("1").executes {
-            it.source later { message.channel.send("[$name] First argument!") }
-            0
-        }.then(literal<Cmd>("2").executes {
-            it.source later { message.channel.send("[$name] Second argument used after first argument!") }
-            0
-        })).then(literal<Cmd>("3").executes {
-            it.source later { message.channel.send("[$name] Second argument used without first argument!") }
-            0
-        })
+        literal("kami") {
+            doesLater {
+                message.channel.send("[$name] First argument!")
+            }
+            literal("blue") {
+                doesLater {
+                    message.channel.send("[$name] Second argument used after first argument!")
+                }
+            }
+        }
+        literal("foo") {
+            doesLater { message.channel.send("[$name] Second argument used without first argument!") }
+        }
+        literal("count") {
+            greedyString("sentence") {
+                doesLater { context ->
+                    // Explicit types are necessary for type inference
+                    val sentence: String = context arg "sentence"
+                    message.channel.send("[$name] There's ${sentence.length} characters in that sentence!")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Also changed ExampleCommand to be a little less confusing. The `1`, `2`, `3` system did not very well convey the command hierarchy.
Instead, I changed the commands to be:
* `kami [blue]`
* `foo`

And added:
* `count <sentence>` to show how required arguments should be used.