### PR TITLE
Add slowmode commands

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -9,6 +9,7 @@ import net.ayataka.kordis.DiscordClient
 import net.ayataka.kordis.Kordis
 import net.ayataka.kordis.entity.server.enums.ActivityType
 import net.ayataka.kordis.entity.server.enums.UserStatus
+import net.ayataka.kordis.entity.channel.TextChannel
 import net.ayataka.kordis.event.EventHandler
 import net.ayataka.kordis.event.events.message.MessageReceiveEvent
 import java.awt.Color
@@ -134,5 +135,14 @@ object Main {
         ERROR(Color(14565692)),
         WARN(Color(14595644)),
         SUCCESS(Color(3989082));
+    }
+
+    suspend fun missingPermissionEmbed(channel: TextChannel) {
+        channel.send {
+            embed {
+                field("Error", "You don't have permission to use this command!", true)
+                color = Colors.ERROR.color
+            }
+        }
     }
 }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -9,7 +9,6 @@ import net.ayataka.kordis.DiscordClient
 import net.ayataka.kordis.Kordis
 import net.ayataka.kordis.entity.server.enums.ActivityType
 import net.ayataka.kordis.entity.server.enums.UserStatus
-import net.ayataka.kordis.entity.channel.TextChannel
 import net.ayataka.kordis.event.EventHandler
 import net.ayataka.kordis.event.events.message.MessageReceiveEvent
 import java.awt.Color

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -136,13 +136,4 @@ object Main {
         WARN(Color(14595644)),
         SUCCESS(Color(3989082));
     }
-
-    suspend fun missingPermissionEmbed(channel: TextChannel) {
-        channel.send {
-            embed {
-                field("Error", "You don't have permission to use this command!", true)
-                color = Colors.ERROR.color
-            }
-        }
-    }
 }

--- a/src/main/kotlin/commands/SlowCommand.kt
+++ b/src/main/kotlin/commands/SlowCommand.kt
@@ -1,6 +1,9 @@
 package commands
 
 import Command
+import PermissionTypes
+import Permissions
+import StringHelper
 import StringHelper.MessageTypes.MISSING_PERMISSIONS
 import arg
 import doesLater
@@ -36,7 +39,8 @@ object SlowCommand : Command("slow") {
     }
 
     override fun getHelpUsage(): String {
-        return "Enables for this channel for an amount of time." +
-                "`;$name <wait> <time>`"
+        return "Enables slowmode for this channel, for a specified amount of time\n\n" +
+                "Usage:\n" +
+                "`;$name 10 60`"
     }
 }

--- a/src/main/kotlin/commands/SlowCommand.kt
+++ b/src/main/kotlin/commands/SlowCommand.kt
@@ -8,39 +8,27 @@ import StringHelper.MessageTypes.MISSING_PERMISSIONS
 import arg
 import doesLater
 import integer
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 object SlowCommand : Command("slow") {
     init {
         integer("wait") {
-            integer("time") {
-                doesLater { context ->
-                    if (!Permissions.hasPermission(message, PermissionTypes.COUNCIL_MEMBER)) {
-                        StringHelper.sendMessage(message.channel, MISSING_PERMISSIONS)
-                        return@doesLater
-                    }
-                    val wait: Int = context arg "wait"
-                    val time: Int = context arg "time"
-                    val originalWait = message.serverChannel!!.rateLimitPerUser
-                    message.serverChannel!!.edit {
-                        rateLimitPerUser = wait
-                    }
-                    GlobalScope.launch {
-                        delay(time * 1000L)
-                        message.serverChannel!!.edit {
-                            rateLimitPerUser = originalWait
-                        }
-                    }
+            doesLater { context ->
+                if (!Permissions.hasPermission(message, PermissionTypes.COUNCIL_MEMBER)) {
+                    StringHelper.sendMessage(message.channel, MISSING_PERMISSIONS)
+                    return@doesLater
+                }
+                val wait: Int = context arg "wait"
+                message.serverChannel!!.edit {
+                    rateLimitPerUser = wait
                 }
             }
+
         }
     }
 
     override fun getHelpUsage(): String {
-        return "Enables slowmode for this channel, for a specified amount of time\n\n" +
+        return "Enables slowmode for this channel, specifying the wait in seconds.\n\n" +
                 "Usage:\n" +
-                "`;$name 10 60`"
+                "`;$name 10`"
     }
 }

--- a/src/main/kotlin/commands/SlowCommand.kt
+++ b/src/main/kotlin/commands/SlowCommand.kt
@@ -1,6 +1,7 @@
 package commands
 
 import Command
+import StringHelper.MessageTypes.MISSING_PERMISSIONS
 import arg
 import doesLater
 import integer
@@ -13,8 +14,8 @@ object SlowCommand : Command("slow") {
         integer("wait") {
             integer("time") {
                 doesLater { context ->
-                    if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
-                        Main.missingPermissionEmbed(message.channel)
+                    if (!Permissions.hasPermission(message, PermissionTypes.COUNCIL_MEMBER)) {
+                        StringHelper.sendMessage(message.channel, MISSING_PERMISSIONS)
                         return@doesLater
                     }
                     val wait: Int = context arg "wait"

--- a/src/main/kotlin/commands/SlowCommand.kt
+++ b/src/main/kotlin/commands/SlowCommand.kt
@@ -13,6 +13,15 @@ object SlowCommand : Command("slow") {
         integer("wait") {
             integer("time") {
                 doesLater { context ->
+                    if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
+                        message.channel.send {
+                            embed {
+                                field("Error", "You don't have permission to use this command!", true)
+                                color = Main.Colors.ERROR.color
+                            }
+                        }
+                        return@doesLater
+                    }
                     val wait: Int = context arg "wait"
                     val time: Int = context arg "time"
                     val originalWait = message.serverChannel!!.rateLimitPerUser

--- a/src/main/kotlin/commands/SlowCommand.kt
+++ b/src/main/kotlin/commands/SlowCommand.kt
@@ -1,0 +1,37 @@
+package commands
+
+import Command
+import arg
+import doesLater
+import integer
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+object SlowCommand : Command("slow") {
+    init {
+        integer("wait") {
+            integer("time") {
+                doesLater { context ->
+                    val wait: Int = context arg "wait"
+                    val time: Int = context arg "time"
+                    val originalWait = message.serverChannel!!.rateLimitPerUser
+                    message.serverChannel!!.edit {
+                        rateLimitPerUser = wait
+                    }
+                    GlobalScope.launch {
+                        delay(time * 1000L)
+                        message.serverChannel!!.edit {
+                            rateLimitPerUser = originalWait
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun getHelpUsage(): String {
+        return "Enables for this channel for an amount of time." +
+                "`;$name <wait> <time>`"
+    }
+}

--- a/src/main/kotlin/commands/SlowCommand.kt
+++ b/src/main/kotlin/commands/SlowCommand.kt
@@ -14,12 +14,7 @@ object SlowCommand : Command("slow") {
             integer("time") {
                 doesLater { context ->
                     if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
-                        message.channel.send {
-                            embed {
-                                field("Error", "You don't have permission to use this command!", true)
-                                color = Main.Colors.ERROR.color
-                            }
-                        }
+                        Main.missingPermissionEmbed(message.channel)
                         return@doesLater
                     }
                     val wait: Int = context arg "wait"

--- a/src/main/kotlin/commands/UnSlowCommand.kt
+++ b/src/main/kotlin/commands/UnSlowCommand.kt
@@ -1,0 +1,19 @@
+package commands
+
+import Command
+import doesLater
+
+object UnSlowCommand : Command("unslow") {
+    init {
+        doesLater {
+            message.serverChannel!!.edit {
+                rateLimitPerUser = 0
+            }
+        }
+    }
+
+    override fun getHelpUsage(): String {
+        return "Remove slow mode from this channel." +
+                "`;$name`"
+    }
+}

--- a/src/main/kotlin/commands/UnSlowCommand.kt
+++ b/src/main/kotlin/commands/UnSlowCommand.kt
@@ -1,6 +1,9 @@
 package commands
 
 import Command
+import PermissionTypes
+import Permissions
+import StringHelper
 import StringHelper.MessageTypes.MISSING_PERMISSIONS
 import doesLater
 
@@ -18,7 +21,8 @@ object UnSlowCommand : Command("unslow") {
     }
 
     override fun getHelpUsage(): String {
-        return "Remove slow mode from this channel." +
+        return "Removes slowmode from this channel\n\n" +
+                "Usage:\n" +
                 "`;$name`"
     }
 }

--- a/src/main/kotlin/commands/UnSlowCommand.kt
+++ b/src/main/kotlin/commands/UnSlowCommand.kt
@@ -6,6 +6,15 @@ import doesLater
 object UnSlowCommand : Command("unslow") {
     init {
         doesLater {
+            if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
+                message.channel.send {
+                    embed {
+                        field("Error", "You don't have permission to use this command!", true)
+                        color = Main.Colors.ERROR.color
+                    }
+                }
+                return@doesLater
+            }
             message.serverChannel!!.edit {
                 rateLimitPerUser = 0
             }

--- a/src/main/kotlin/commands/UnSlowCommand.kt
+++ b/src/main/kotlin/commands/UnSlowCommand.kt
@@ -1,13 +1,14 @@
 package commands
 
 import Command
+import StringHelper.MessageTypes.MISSING_PERMISSIONS
 import doesLater
 
 object UnSlowCommand : Command("unslow") {
     init {
         doesLater {
-            if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
-                Main.missingPermissionEmbed(message.channel)
+            if (!Permissions.hasPermission(message, PermissionTypes.COUNCIL_MEMBER)) {
+                StringHelper.sendMessage(message.channel, MISSING_PERMISSIONS)
                 return@doesLater
             }
             message.serverChannel!!.edit {

--- a/src/main/kotlin/commands/UnSlowCommand.kt
+++ b/src/main/kotlin/commands/UnSlowCommand.kt
@@ -7,12 +7,7 @@ object UnSlowCommand : Command("unslow") {
     init {
         doesLater {
             if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
-                message.channel.send {
-                    embed {
-                        field("Error", "You don't have permission to use this command!", true)
-                        color = Main.Colors.ERROR.color
-                    }
-                }
+                Main.missingPermissionEmbed(message.channel)
                 return@doesLater
             }
             message.serverChannel!!.edit {


### PR DESCRIPTION
Adds two commands:
`;slow <wait> <time>`: changes slowmode in the channel to `wait` seconds for `time` seconds
`;unslow`: sets slowmode in the channel to 0
(resolving #4).

Also adds a function to send the no permissions embed in a channel to avoid repeating code.
