### PR TITLE
add purge command

### DIFF
--- a/src/main/kotlin/commands/PurgeCommand.kt
+++ b/src/main/kotlin/commands/PurgeCommand.kt
@@ -1,6 +1,7 @@
 package commands
 
 import Command
+import StringHelper.MessageTypes.MISSING_PERMISSIONS
 import arg
 import doesLater
 import greedyString
@@ -11,8 +12,8 @@ object PurgeCommand : Command("purge") {
     init {
         integer("number") {
             doesLater { context ->
-                if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
-                    //Main.missingPermissionEmbed(message.channel) assuming my other pr gets merged (#20) this can be used...
+                if (!Permissions.hasPermission(message, PermissionTypes.COUNCIL_MEMBER)) {
+                    StringHelper.sendMessage(message.channel, MISSING_PERMISSIONS)
                     return@doesLater
                 }
                 val number: Int = context arg "number"
@@ -20,8 +21,8 @@ object PurgeCommand : Command("purge") {
             }
             greedyString("user") {
                 doesLater { context ->
-                    if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
-                        //Main.missingPermissionEmbed(message.channel) assuming my other pr gets merged (#20) this can be used...
+                    if (!Permissions.hasPermission(message, PermissionTypes.COUNCIL_MEMBER)) {
+                        StringHelper.sendMessage(message.channel, MISSING_PERMISSIONS)
                         return@doesLater
                     }
                     val number: Int = context arg "number"

--- a/src/main/kotlin/commands/PurgeCommand.kt
+++ b/src/main/kotlin/commands/PurgeCommand.kt
@@ -1,0 +1,31 @@
+package commands
+
+import Command
+import arg
+import doesLater
+import greedyString
+import integer
+import literal
+import string
+
+object PurgeCommand : Command("purge") {
+    init {
+        integer("number") {
+            doesLater { context ->
+                if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
+                    //Main.missingPermissionEmbed(message.channel) assuming my other pr gets merged (#20) this can be used...
+                    return@doesLater
+                }
+                val number: Int = context arg "number"
+                for (message in message.channel.getMessages(number)) {
+                    message.delete()
+                }
+            }
+        }
+    }
+
+    override fun getHelpUsage(): String {
+        return "Purges a number of messages in a channel based on parameters.\n" +
+                "`;$name <number>`"
+    }
+}

--- a/src/main/kotlin/commands/PurgeCommand.kt
+++ b/src/main/kotlin/commands/PurgeCommand.kt
@@ -4,6 +4,7 @@ import Command
 import arg
 import doesLater
 import integer
+import long
 import net.ayataka.kordis.entity.deleteAll
 
 object PurgeCommand : Command("purge") {
@@ -17,11 +18,24 @@ object PurgeCommand : Command("purge") {
                 val number: Int = context arg "number"
                 message.channel.getMessages(number).deleteAll()
             }
+            long("user") {
+                doesLater { context ->
+                    if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
+                        //Main.missingPermissionEmbed(message.channel) assuming my other pr gets merged (#20) this can be used...
+                        return@doesLater
+                    }
+                    val number: Int = context arg "number"
+                    val user: Long = context arg "user"
+                    val search = if (number < 1000) number * 2 + 50 else number
+                    message.channel.getMessages(search).filter { it.author!!.id == user }.take(number).deleteAll()
+                }
+            }
         }
     }
 
     override fun getHelpUsage(): String {
         return "Purges a number of messages in a channel based on parameters.\n" +
-                "`;$name <number>`"
+                "`;$name <number>`" +
+                "`;$name <number> <userid>`"
     }
 }

--- a/src/main/kotlin/commands/PurgeCommand.kt
+++ b/src/main/kotlin/commands/PurgeCommand.kt
@@ -3,8 +3,8 @@ package commands
 import Command
 import arg
 import doesLater
+import greedyString
 import integer
-import long
 import net.ayataka.kordis.entity.deleteAll
 
 object PurgeCommand : Command("purge") {
@@ -18,16 +18,16 @@ object PurgeCommand : Command("purge") {
                 val number: Int = context arg "number"
                 message.channel.getMessages(number).deleteAll()
             }
-            long("user") {
+            greedyString("user") {
                 doesLater { context ->
                     if (!server!!.members.find(message.author!!.id)!!.canManage(message.serverChannel!!)) {
                         //Main.missingPermissionEmbed(message.channel) assuming my other pr gets merged (#20) this can be used...
                         return@doesLater
                     }
                     val number: Int = context arg "number"
-                    val user: Long = context arg "user"
+                    val user: String = context arg "user"
                     val search = if (number < 1000) number * 2 + 50 else number
-                    message.channel.getMessages(search).filter { it.author!!.id == user }.take(number).deleteAll()
+                    message.channel.getMessages(search).filter { it.author!!.id.toString() == user || it.author!!.mention == user || it.author!!.tag == user }.take(number).deleteAll()
                 }
             }
         }

--- a/src/main/kotlin/commands/PurgeCommand.kt
+++ b/src/main/kotlin/commands/PurgeCommand.kt
@@ -3,10 +3,8 @@ package commands
 import Command
 import arg
 import doesLater
-import greedyString
 import integer
-import literal
-import string
+import net.ayataka.kordis.entity.deleteAll
 
 object PurgeCommand : Command("purge") {
     init {
@@ -17,9 +15,7 @@ object PurgeCommand : Command("purge") {
                     return@doesLater
                 }
                 val number: Int = context arg "number"
-                for (message in message.channel.getMessages(number)) {
-                    message.delete()
-                }
+                message.channel.getMessages(number).deleteAll()
             }
         }
     }


### PR DESCRIPTION
Adds a purge command described by #3 and #10 functionality for #10 is done, #3 still needs to be done, draft pr so that it is known I am already working on this.

Adds a purge command:
`;purge <number>` purges `number` messages from the channel it is used in.

Useful command for moderation.