### PR TITLE
[new] Added ;rickroll command

### DIFF
--- a/src/main/kotlin/org/kamiblue/botkt/command/commands/fun/RickRollCommand.kt
+++ b/src/main/kotlin/org/kamiblue/botkt/command/commands/fun/RickRollCommand.kt
@@ -1,0 +1,31 @@
+package org.kamiblue.botkt.command.commands.`fun`
+
+import org.kamiblue.botkt.command.BotCommand
+import org.kamiblue.botkt.command.Category
+import org.kamiblue.botkt.utils.MessageUtils.error
+import org.kamiblue.botkt.utils.StringUtils.isUrl
+
+object RickRollCommand : BotCommand(
+    name = "rickroll",
+    alias = arrayOf("rick", "rickastley"),
+    category = Category.FUN,
+    description = "Never gonna give you up, Never gonna let you down..."
+) {
+    private val cdnRegex = "https://cdn.discordapp.com/attachments/(\\d{18})/(\\d{18})/(.*\$)".toRegex()
+
+    init {
+        string("url") { urlArg ->
+            execute {
+                val url = urlArg.value
+                if (!url.isUrl()) {
+                    message.channel.error("Invalid url!")
+                    return@execute
+                }
+                val redirectLink = url.replace(cdnRegex, "https://cdn.dircordapp.com/attachments/$1/$2/$3")
+                message.delete()
+                message.channel.send(redirectLink)
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/org/kamiblue/botkt/command/commands/fun/RickRollCommand.kt
+++ b/src/main/kotlin/org/kamiblue/botkt/command/commands/fun/RickRollCommand.kt
@@ -12,6 +12,7 @@ object RickRollCommand : BotCommand(
     description = "Never gonna give you up, Never gonna let you down..."
 ) {
     private val cdnRegex = "https://cdn.discordapp.com/attachments/(\\d{18})/(\\d{18})/(.*\$)".toRegex()
+    private const val urlPrefix = "https://cdn.dircordapp.com/attachments"
 
     init {
         string("url") { urlArg ->
@@ -21,7 +22,7 @@ object RickRollCommand : BotCommand(
                     message.channel.error("Invalid url!")
                     return@execute
                 }
-                val redirectLink = url.replace(cdnRegex, "https://cdn.dircordapp.com/attachments/$1/$2/$3")
+                val redirectLink = url.replace(cdnRegex, "$urlPrefix/$1/$2/$3")
                 message.delete()
                 message.channel.send(redirectLink)
             }

--- a/src/main/kotlin/org/kamiblue/botkt/command/commands/fun/RickRollCommand.kt
+++ b/src/main/kotlin/org/kamiblue/botkt/command/commands/fun/RickRollCommand.kt
@@ -11,14 +11,14 @@ object RickRollCommand : BotCommand(
     category = Category.FUN,
     description = "Never gonna give you up, Never gonna let you down..."
 ) {
-    private val cdnRegex = "https://cdn.discordapp.com/attachments/(\\d{18})/(\\d{18})/(.*\$)".toRegex()
+    private val cdnRegex = "https://cdn.discordapp.com/attachments/(\\d{18})/(\\d{18})/(.*$)".toRegex()
     private const val urlPrefix = "https://cdn.dircordapp.com/attachments"
 
     init {
         string("url") { urlArg ->
             execute {
                 val url = urlArg.value
-                if (!url.isUrl()) {
+                if (!url.isUrl() || !url.matches(cdnRegex)) {
                     message.channel.error("Invalid url!")
                     return@execute
                 }


### PR DESCRIPTION
This command replaces the Discord cdn url [https://cdn.discordapp.com](url) with [https://cdn.dircordapp.com](url)
The image embed will be shown normally in the discord but the link redirects you to rick roll video in browser
